### PR TITLE
Relative import

### DIFF
--- a/birefnet.py
+++ b/birefnet.py
@@ -1,11 +1,11 @@
 import torch, os
 import sys
-sys.path.insert(0, os.path.dirname(__file__))
+# sys.path.insert(0, os.path.dirname(__file__))
 
 import torch.nn.functional as F
 from PIL import Image
-from models.baseline import BiRefNet
-from config import Config
+from .models.baseline import BiRefNet
+from .config import Config
 from torchvision.transforms.functional import normalize
 import numpy as np
 import folder_paths

--- a/dataset.py
+++ b/dataset.py
@@ -5,9 +5,9 @@ from PIL import Image
 from torch.utils import data
 from torchvision import transforms
 
-from preproc import preproc
-from config import Config
-from utils import path_to_image
+from .preproc import preproc
+from .config import Config
+from .utils import path_to_image
 
 
 Image.MAX_IMAGE_PIXELS = None       # remove DecompressionBombWarning

--- a/models/backbones/build_backbone.py
+++ b/models/backbones/build_backbone.py
@@ -2,9 +2,9 @@ import torch
 import torch.nn as nn
 from collections import OrderedDict
 from torchvision.models import vgg16, vgg16_bn, VGG16_Weights, VGG16_BN_Weights, resnet50, ResNet50_Weights
-from models.backbones.pvt_v2 import pvt_v2_b2, pvt_v2_b5
-from models.backbones.swin_v1 import swin_v1_t, swin_v1_s, swin_v1_b, swin_v1_l
-from config import Config
+from .pvt_v2 import pvt_v2_b2, pvt_v2_b5
+from .swin_v1 import swin_v1_t, swin_v1_s, swin_v1_b, swin_v1_l
+from ...config import Config
 
 
 config = Config()

--- a/models/baseline.py
+++ b/models/baseline.py
@@ -8,16 +8,16 @@ from torchvision.models import vgg16, vgg16_bn
 from torchvision.models import resnet50
 from kornia.filters import laplacian
 
-from models.backbones.build_backbone import build_backbone
-from models.modules.decoder_blocks import BasicDecBlk, ResBlk, HierarAttDecBlk
-from models.modules.lateral_blocks import BasicLatBlk
-from models.modules.aspp import ASPP, ASPPDeformable
-from models.modules.ing import *
-from models.refinement.refiner import Refiner, RefinerPVTInChannels4, RefUNet
-from models.refinement.stem_layer import StemLayer
+from .backbones.build_backbone import build_backbone
+from .modules.decoder_blocks import BasicDecBlk, ResBlk, HierarAttDecBlk
+from .modules.lateral_blocks import BasicLatBlk
+from .modules.aspp import ASPP, ASPPDeformable
+from .modules.ing import *
+from .refinement.refiner import Refiner, RefinerPVTInChannels4, RefUNet
+from .refinement.stem_layer import StemLayer
 
-from config import Config
-from dataset import class_labels_TR_sorted
+from ..config import Config
+from ..dataset import class_labels_TR_sorted
 
 
 class BiRefNet(nn.Module):

--- a/models/modules/decoder_blocks.py
+++ b/models/modules/decoder_blocks.py
@@ -1,8 +1,8 @@
 import torch
 import torch.nn as nn
-from models.modules.aspp import ASPP, ASPPDeformable
-from models.modules.attentions import PSA, SGE
-from config import Config
+from .aspp import ASPP, ASPPDeformable
+from .attentions import PSA, SGE
+from ...config import Config
 
 
 config = Config()

--- a/models/refinement/refiner.py
+++ b/models/refinement/refiner.py
@@ -7,13 +7,13 @@ import torch.nn.functional as F
 from torchvision.models import vgg16, vgg16_bn
 from torchvision.models import resnet50
 
-from config import Config
-from dataset import class_labels_TR_sorted
-from models.backbones.build_backbone import build_backbone
-from models.modules.decoder_blocks import BasicDecBlk
-from models.modules.lateral_blocks import BasicLatBlk
-from models.modules.ing import *
-from models.refinement.stem_layer import StemLayer
+from ...config import Config
+from ...dataset import class_labels_TR_sorted
+from ..backbones.build_backbone import build_backbone
+from ..modules.decoder_blocks import BasicDecBlk
+from ..modules.lateral_blocks import BasicLatBlk
+from ..modules.ing import *
+from .stem_layer import StemLayer
 
 
 class RefinerPVTInChannels4(nn.Module):


### PR DESCRIPTION
在 ComfyUI 的 Node 插件机制下，绝对路径 import 会带来很多问题，比如
```
from utils import path_to_image
```
会找到 ComfyUI 的 utils.py 而不是节点的，包括很多其他的地方，直接暴力使用 `sys.path.insert(0, xxx)` 并不是个好的实践，因为会导致其他节点发生莫名其妙的问题，在节点内部全部使用相对 import 才是最优解。
